### PR TITLE
Make create repository dialog behave consistently when initializing a repository

### DIFF
--- a/app/src/ui/add-repository/create-repository.tsx
+++ b/app/src/ui/add-repository/create-repository.tsx
@@ -96,7 +96,7 @@ export class CreateRepository extends React.Component<
     super(props)
 
     const path = this.props.initialPath
-      ? this.props.initialPath
+      ? Path.dirname(this.props.initialPath)
       : getDefaultDir()
 
     const name = this.props.initialPath

--- a/app/src/ui/add-repository/create-repository.tsx
+++ b/app/src/ui/add-repository/create-repository.tsx
@@ -535,6 +535,7 @@ export class CreateRepository extends React.Component<
               label="Name"
               placeholder="repository name"
               onValueChanged={this.onNameChanged}
+              disabled={readOnlyPath}
             />
           </Row>
 


### PR DESCRIPTION
See https://github.com/desktop/desktop/issues/9651

## Description

Make the create repository dialog behave in a consistent way when creating a repository or initializing a repository.

- Make the combination of `Name` + `Local Path` point at the dir to be created/initialized
- Disable the `Name` text box when initializing a repository at a read-only path

### Screenshots

#### After

- The `Name` text box is disabled
- The combination of `Name` + `Local Path` points to the directory to be initialized
- The `Description` text box is selected

![image](https://user-images.githubusercontent.com/11719160/80916133-c9c02600-8d4e-11ea-8eb0-3a09e25b04a3.png)

#### Before

- The `Name` text box is enabled (but its contents aren't used)
- The `Name` text box is selected
- `Name` and `Local Path` have the same directory name

![image](https://user-images.githubusercontent.com/11719160/80916098-94b3d380-8d4e-11ea-8bd9-83bac8416d0e.png)

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
